### PR TITLE
Client : MTV 기반 충돌 해결 구현

### DIFF
--- a/Client/Client/Collider.cpp
+++ b/Client/Client/Collider.cpp
@@ -210,27 +210,27 @@ XMFLOAT3 GetAABB_MTV(const XMFLOAT3& centerA, const XMFLOAT3& extentA,
 	float px = (extentA.x + extentB.x) - std::abs(dx);
 	if (px <= 0) return { 0.0f, 0.0f, 0.0f };
 
-	/*float dy = centerB.y - centerA.y;
+	float dy = centerB.y - centerA.y;
 	float py = (extentA.y + extentB.y) - std::abs(dy);
-	if (py <= 0) return { 0.0f, 0.0f, 0.0f };*/
+	if (py <= 0) return { 0.0f, 0.0f, 0.0f };
 
 	float dz = centerB.z - centerA.z;
 	float pz = (extentA.z + extentB.z) - std::abs(dz);
 	if (pz <= 0) return { 0.0f, 0.0f, 0.0f };
 
 	// 최소 겹침 축 선택
-	if (px < pz) {
+	/*if (px < pz) {
 		return { dx < 0 ? -px : px, 0.0f, 0.0f };
 	}
 	else {
 		return { 0.0f, 0.0f, dz < 0 ? -pz : pz };
-	}
-	/*if (px < py && px < pz)
-		return { dx < 0 ? -px : px, 0.0f, 0.0f };
+	}*/
+	if (px < py && px < pz)
+		return { dx < 0 ? px : -px, 0.0f, 0.0f };
 	else if (py < pz)
-		return { 0.0f, dy < 0 ? -py : py, 0.0f };
+		return { 0.0f, dy < 0 ? py : -py, 0.0f };
 	else
-		return { 0.0f, 0.0f, dz < 0 ? -pz : pz };*/
+		return { 0.0f, 0.0f, dz < 0 ? pz : -pz };
 }
 
 XMFLOAT3 CCollider::GetCorrectionVector(std::shared_ptr<CCollider>& pCollider)

--- a/Client/Client/GameObject.cpp
+++ b/Client/Client/GameObject.cpp
@@ -231,9 +231,9 @@ BoundingBox CGameObject::GetMergedBoundingBox(BoundingBox* pVolume)
 	{
 		BoundingBox boundingBox{};
 
-		if (auto pCollider = GetComponent<CCollider>())
+		if (m_pMesh)
 		{
-			BoundingBox::CreateMerged(boundingBox, boundingBox, pCollider->GetBoundingBox());
+			BoundingBox::CreateMerged(boundingBox, boundingBox, m_pMesh->GetBoundingBox());
 		}
 
 		for (auto& pChild : m_pChilds)
@@ -244,9 +244,9 @@ BoundingBox CGameObject::GetMergedBoundingBox(BoundingBox* pVolume)
 		return boundingBox;
 	}
 	else {
-		if (auto pCollider = GetComponent<CCollider>())
+		if (m_pMesh)
 		{
-			BoundingBox::CreateMerged(*pVolume, *pVolume, pCollider->GetBoundingBox());
+			BoundingBox::CreateMerged(*pVolume, *pVolume, m_pMesh->GetBoundingBox());
 		}
 
 		for (auto& pChild : m_pChilds)

--- a/Client/Client/GameObject.cpp
+++ b/Client/Client/GameObject.cpp
@@ -330,10 +330,6 @@ void CGameObject::Render(ID3D12GraphicsCommandList* pd3dCommandList, CCamera* pC
 void CGameObject::SetMesh(std::shared_ptr<CMesh> pMesh)
 {
 	m_pMesh = pMesh; 
-	if (m_pMesh->GetType() && VERTEXT_POSITION) {
-		auto pCollider = AddComponent<DefaultCollider>(shared_from_this());
-		pCollider->SetCollider(m_pMesh);
-	}
 }
 
 void CGameObject::SetShader(std::shared_ptr<CShader> pShader, int nIndex)

--- a/Client/Client/Mesh.cpp
+++ b/Client/Client/Mesh.cpp
@@ -104,6 +104,13 @@ void CMesh::SetSubMeshCount(int nSubMeshes)
 	m_pd3dSubSetIndexBufferViews.resize(nSubMeshes);
 }
 
+BoundingBox CMesh::GetBoundingBox(const XMFLOAT4X4& xmf4x4WorldMatrix)
+{
+	BoundingBox boundingBox;
+	m_xmBoundingBox.Transform(boundingBox, XMLoadFloat4x4(&xmf4x4WorldMatrix));
+	return boundingBox;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 
@@ -160,7 +167,7 @@ void CStandardMesh::LoadMeshFromFile(ID3D12Device* pd3dDevice, ID3D12GraphicsCom
 		{
 			File.read((char*)&m_xmf3AABBCenter, sizeof(XMFLOAT3));
 			File.read((char*)&m_xmf3AABBExtents, sizeof(XMFLOAT3));
-
+			m_xmBoundingBox = BoundingBox(m_xmf3AABBCenter, m_xmf3AABBExtents);
 			/*{
 				std::string debugOutput = m_strMeshName + " ";
 				debugOutput += "/ Center : " + std::to_string(m_xmf3AABBCenter.x) + ", " + std::to_string(m_xmf3AABBCenter.y) + ", " + std::to_string(m_xmf3AABBCenter.z);

--- a/Client/Client/Mesh.h
+++ b/Client/Client/Mesh.h
@@ -172,7 +172,11 @@ protected:
 	// Index 데이터의 갯수에 따라서 인덱스 버퍼를 생성하는 함수
 	void SetSubMeshCount(int nSubMeshes);
 
+	BoundingBox GetBoundingBox(const XMFLOAT4X4& xmf4x4WorldMatrix);
+
 protected:
+	// AABB
+	BoundingBox m_xmBoundingBox;	// AABB
 	XMFLOAT3 m_xmf3AABBCenter;	// AABB의 중심
 	XMFLOAT3 m_xmf3AABBExtents;	// AABB의 반지름
 };

--- a/Client/Client/RigidBody.cpp
+++ b/Client/Client/RigidBody.cpp
@@ -116,7 +116,7 @@ void CRigidBody::Integrate(float deltaTime, XMFLOAT3& position, XMFLOAT4& rotati
 void CRigidBody::ApplyCorrection(const XMFLOAT3& xmf3Correction)
 {
 	m_pTransform->Move(xmf3Correction);
-	m_xmf3Velocity = XMFLOAT3(0.0f, 0.0f, 0.0f); // 속도 초기화
+	m_xmf3Velocity = Vector3::ScalarProduct(m_xmf3Velocity, -1.0f); // 속도 초기화
 }
 
 void CRigidBody::UpdateVelocity(float fTimeElapsed)


### PR DESCRIPTION
현재 구현 방식 : ModelInfo에서 Model이 가진 모든 Mesh의 bound를 포함하는 BoundingBox를 계산
해당 BoundingBox를 Collider로 생성 후 RootObject에서만 충돌 처리 수행중.